### PR TITLE
Add dependent lookup support to LookupAttribute and IMappingLookup

### DIFF
--- a/src/Lookup/LookupAttribute.cs
+++ b/src/Lookup/LookupAttribute.cs
@@ -4,6 +4,12 @@ public class LookupAttribute : Attribute
 {
     public Type LookupType { get; }
 
+    /// <summary>
+    /// Names of sibling properties this lookup depends on. When any listed property
+    /// changes the lookup options should be reloaded with those values as parameters.
+    /// </summary>
+    public string[]? DependsOn { get; set; }
+
     public LookupAttribute(Type lookupType)
     {
         LookupType = lookupType;

--- a/src/Mappings/IMappingLookup.cs
+++ b/src/Mappings/IMappingLookup.cs
@@ -4,5 +4,12 @@ namespace EdNexusData.Broker.Common.Mappings;
 
 public interface IMappingLookup
 {
-    public Task<List<SelectListItem>> SelectListAsync();
+    Task<List<SelectListItem>> SelectListAsync();
+
+    /// <summary>
+    /// Returns a filtered list based on values selected in dependent properties.
+    /// Defaults to the unfiltered list; override to implement filtering.
+    /// </summary>
+    Task<List<SelectListItem>> SelectListAsync(Dictionary<string, string?> dependentValues)
+        => SelectListAsync();
 }


### PR DESCRIPTION
LookupAttribute gains a DependsOn string array so connector developers can declare which sibling properties a lookup depends on. IMappingLookup gains a default SelectListAsync(Dictionary<string,string?>) overload that connectors override to filter options; callers that do not supply parameters continue to call the existing parameterless method unchanged.